### PR TITLE
Some modifications to compile Cambio on Linux boxes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,9 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-set( Boost_USE_STATIC_LIBS ON )
-set( CMAKE_FIND_LIBRARY_SUFFIXES .a .la .lib ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+if( Boost_USE_STATIC_LIBS )
+  set( CMAKE_FIND_LIBRARY_SUFFIXES .a .la .lib )
+endif()
 
 
 set( headers ${headers} cambio/Cambio_config.h.in )
@@ -148,6 +149,7 @@ endif( APPLE AND BUILD_CAMBIO_GUI )
 if( BUILD_CAMBIO_COMMAND_LINE )
   set( headers ${headers} cambio/CommandLineUtil.h )
   set( sources ${sources} src/CommandLineUtil.cpp )
+  find_library( BOOST_PROGRAM_OPTIONS boost_program_options REQUIRED)
 endif( BUILD_CAMBIO_COMMAND_LINE )
 
 if( NOT BUILD_CAMBIO_GUI AND NOT BUILD_CAMBIO_COMMAND_LINE )
@@ -157,12 +159,16 @@ endif( NOT BUILD_CAMBIO_GUI AND NOT BUILD_CAMBIO_COMMAND_LINE )
 
 add_executable( ${PROJECT_NAME} ${GUI_TYPE} main.cpp ${sources} ${headers} )
 
+if( BUILD_CAMBIO_COMMAND_LINE )
+  target_link_libraries( ${PROJECT_NAME} PRIVATE ${BOOST_PROGRAM_OPTIONS} )
+endif()
+
 if( NOT BUILD_CAMBIO_GUI )
   if( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
     #Right now we are copying all of libpthread into our executable to force copying weak symbols in.
     #  Instead, to save size should specify the functions we actually need using '-u pthread_create', etc.
     #  Could maybe add a "-no_weak_exports" flag to the linker as well to make sure none missing.
-    set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-static -pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
+    set( CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} "-pthread -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
     target_link_libraries( ${PROJECT_NAME} PRIVATE -static-libgcc -static-libstdc++ )
   endif( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
 endif( NOT BUILD_CAMBIO_GUI )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if( BUILD_CAMBIO_GUI )
 
   if(WIN32)
     find_package(Qt5 COMPONENTS WinExtras REQUIRED)
-  else()
+  elseif( APPLE )
     find_package(Qt5 COMPONENTS MacExtras REQUIRED)
   endif()
 

--- a/src/FileDetailWidget.cpp
+++ b/src/FileDetailWidget.cpp
@@ -44,6 +44,7 @@
 #include "SpecUtils/SpecFile.h"
 #include "cambio/FileDetailTools.h"
 #include "cambio/FileDetailWidget.h"
+#include <cfloat>
 
 using namespace std;
 

--- a/src/SpectrumView.cpp
+++ b/src/SpectrumView.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <limits>
 #include <iostream>
+#include <cfloat>
 
 #include <QtCharts/QChart>
 #include <QBrush>


### PR DESCRIPTION
I've made some modifications in order to build Cambio on my Linux boxes (Fedora 35 (x86_64) w/o static versions of the Boost libraries): the build with Boost static libraries was also tested. 
"#include <cfloat>" was also added to the src/SpecFile_spe.cpp of the SpecUtils.